### PR TITLE
9 improve error handling so it shows filename for the file with the incorrect bytecode or find a workaround to still read the file

### DIFF
--- a/ecc_gui.py
+++ b/ecc_gui.py
@@ -928,7 +928,7 @@ class AppWindow(tk.Frame):
                 appearance_templates.append(appearance)
             index += 1
         for i in range(1, POP_SIZE + 1):
-            morphlist = ecc_logic.get_morphlist_from_appearance(load_appearance(self.chromosome[str(i)]['filename']))
+            morphlist = ecc_logic.get_morphlist_from_appearance(ecc_logic.load_appearance(self.chromosome[str(i)]['filename']))
             updated_appearance = ecc_logic.save_morph_to_appearance(morphlist, appearance_templates[i - 1])
             nude_appearance = ecc_logic.remove_clothing_from_appearance(updated_appearance)
             ecc_logic.save_appearance(nude_appearance, self.chromosome[str(i)]['filename'])

--- a/ecc_logic.py
+++ b/ecc_logic.py
@@ -117,6 +117,7 @@ def load_appearance(filename):
     """ Loads appearance from filename and returns it, or returns False if the appearance couldn't be loaded """
     if os.path.isfile(filename):
         with open(filename, encoding="utf-8") as f:
+            print(f'load_appearance: loading file {filename}')
             return json.load(f)
     return False
 


### PR DESCRIPTION
Added the required logging

I would have preferred to catch the exception, but I would need a faulty test file to test. Should be changed after we know exactly what caused the problem.